### PR TITLE
disable introspection for libsoup and gst-devtools

### DIFF
--- a/modulesets/etc.modules
+++ b/modulesets/etc.modules
@@ -64,7 +64,7 @@
     <branch repo="system"/>
   </systemmodule>
 
-  <autotools id="libsoup">
+  <autotools id="libsoup" autogenargs="--disable-introspection">
     <dependencies>
       <dep package="glib"/>
       <dep package="libxml2"/>

--- a/modulesets/gstreamer-1.2.modules
+++ b/modulesets/gstreamer-1.2.modules
@@ -67,7 +67,7 @@
     <branch repo="gstreamer" module="gst-libav" checkoutdir="gst-libav" tag="1.2.4"/>
   </autotools>
 
-  <autotools id="gst-devtools" autogenargs="--disable-gtk-doc">
+  <autotools id="gst-devtools" autogenargs="--disable-gtk-doc --disable-introspection">
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>

--- a/modulesets/gstreamer.modules
+++ b/modulesets/gstreamer.modules
@@ -67,7 +67,7 @@
     <branch repo="gstreamer" module="gst-libav" checkoutdir="gst-libav"/>
   </autotools>
 
-  <autotools id="gst-devtools" autogenargs="--disable-gtk-doc">
+  <autotools id="gst-devtools" autogenargs="--disable-gtk-doc --disable-introspection">
     <dependencies>
       <dep package="gstreamer"/>
       <dep package="gst-plugins-base"/>


### PR DESCRIPTION
enable instrospection at libsoup and gst-devtools will cause compile error
