### PR TITLE
Add libasound dependency to gst-plugins-base

### DIFF
--- a/modulesets/etc.modules
+++ b/modulesets/etc.modules
@@ -123,6 +123,13 @@
             checkoutdir="libvpx"/>
   </autotools>
 
+  <systemmodule id="libasound">
+    <branch repo="system"/>
+    <systemdependencies>
+      <dep type="c_include" name="alsa/asoundlib.h"/>
+    </systemdependencies>
+  </systemmodule>
+
   <systemmodule id="flex">
     <branch repo="system"/>
     <systemdependencies>

--- a/modulesets/gstreamer-1.2.modules
+++ b/modulesets/gstreamer-1.2.modules
@@ -25,6 +25,7 @@
   <autotools id="gst-plugins-base" autogenargs="--disable-gtk-doc">
     <dependencies>
       <dep package="orc"/>
+      <dep package="libasound"/>
       <dep package="libogg"/>
       <dep package="libtheora"/>
       <dep package="libvorbis"/>

--- a/modulesets/gstreamer.modules
+++ b/modulesets/gstreamer.modules
@@ -25,6 +25,7 @@
   <autotools id="gst-plugins-base" autogenargs="--disable-gtk-doc">
     <dependencies>
       <dep package="orc"/>
+      <dep package="libasound"/>
       <dep package="libogg"/>
       <dep package="libtheora"/>
       <dep package="libvorbis"/>


### PR DESCRIPTION
This is necessary for gst-plugins-base to build alsa
