### PR TITLE
jhbuildrc: don't re-use autoconf cache for development pupose

### DIFF
--- a/gstreamer.jhbuildrc
+++ b/gstreamer.jhbuildrc
@@ -9,9 +9,6 @@ prefix = os.path.join(_basepath, 'install')
 
 build_policy = 'updated-deps'
 
-autogenargs = ''
-autogenargs += ' --cache-file=' + checkoutroot + '/autoconf-cache'
-
 addpath('PKG_CONFIG_PATH', os.path.join(prefix, 'lib64/pkgconfig'))
 addpath('PKG_CONFIG_PATH', '/usr/lib/pkgconfig')
 addpath('PKG_CONFIG_PATH', '/usr/share/pkgconfig')

--- a/modulesets/gnu.modules
+++ b/modulesets/gnu.modules
@@ -28,7 +28,7 @@
     </branch>
   </autotools>
 
-  <autotools id="nettle">
+  <autotools id="nettle" autogen-template="./configure --prefix=%(prefix)s --enable-static">
     <dependencies>
       <dep package="gmp"/>
     </dependencies>


### PR DESCRIPTION
If cache is enabled, it prevents updating configuration.
