### PR TITLE
libjpeg-turbo: for enabling jpegdec

### DIFF
--- a/modulesets/etc.modules
+++ b/modulesets/etc.modules
@@ -111,6 +111,13 @@
             />
   </autotools>
 
+  <autotools id="libjpeg">
+    <branch repo="downloads.sourceforge.net"
+            module="libjpeg-turbo/libjpeg-turbo-1.4.1.tar.gz"
+            version="1.4.1"
+            />
+  </autotools>
+
   <autotools id="libvpx"
              autogen-template="./configure --prefix=%(prefix)s --enable-vp8 --enable-vp9 --enable-shared --disable-static">
     <dependencies>

--- a/modulesets/gstreamer.modules
+++ b/modulesets/gstreamer.modules
@@ -35,6 +35,7 @@
 
   <autotools id="gst-plugins-good" autogenargs="--disable-gtk-doc">
     <dependencies>
+      <dep package="libjpeg"/>
       <dep package="libsoup"/>
       <dep package="libvpx"/>
       <dep package="gstreamer"/>


### PR DESCRIPTION
jpegdec is very frequently required.
