### PR TITLE
Add a list of module to skip for OSX

### DIFF
--- a/gstreamer-1.2.jhbuildrc
+++ b/gstreamer-1.2.jhbuildrc
@@ -20,3 +20,4 @@ from sys import platform as _platform
 if _platform == "darwin":
   os.environ['CFLAGS'] = '-Wno-typedef-redefinition -Wno-error=unused-command-line-argument'
   os.environ['OBJCFLAGS'] = '-Wno-error=deprecated-declarations'
+  skip = ['libasound']

--- a/gstreamer.jhbuildrc
+++ b/gstreamer.jhbuildrc
@@ -18,3 +18,4 @@ from sys import platform as _platform
 if _platform == "darwin":
   os.environ['CFLAGS'] = '-Wno-typedef-redefinition -Wno-error=unused-command-line-argument'
   os.environ['OBJCFLAGS'] = '-Wno-error=deprecated-declarations'
+  skip = ['libasound']


### PR DESCRIPTION
Skip a build libasound for OSX because libasound is an interface
to ALSA driver that is only supported on linux OS.
