### PR TITLE
Specify libxml2's minimum version

### DIFF
--- a/modulesets/etc.modules
+++ b/modulesets/etc.modules
@@ -67,7 +67,7 @@
 
   <systemmodule id="libxml2">
     <pkg-config>libxml-2.0.pc</pkg-config>
-    <branch repo="system"/>
+    <branch repo="system" version="2.8.0"/>
   </systemmodule>
 
   <autotools id="libsoup" autogenargs="--disable-introspection">


### PR DESCRIPTION
A higher than or equal to 2.8 is needed for the dashdemux plugin
in the gst-plugins-bad.
